### PR TITLE
Move `moment` to peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1784,7 +1784,8 @@
 		"moment": {
 			"version": "2.22.2",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+			"integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+			"dev": true
 		},
 		"ms": {
 			"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"url": "https://github.com/moment/moment-timezone/issues"
 	},
 	"license": "MIT",
-	"dependencies": {
+	"peerDependencies": {
 		"moment": ">= 2.9.0"
 	},
 	"devDependencies": {
@@ -34,7 +34,8 @@
 		"grunt-contrib-clean": "^2.0.0",
 		"grunt-contrib-jshint": "^2.1.0",
 		"grunt-contrib-nodeunit": "^2.0.0",
-		"grunt-contrib-uglify": "^4.0.1"
+		"grunt-contrib-uglify": "^4.0.1",
+		"moment": ">= 2.9.0"
 	},
 	"jspm": {
 		"main": "builds/moment-timezone-with-data",


### PR DESCRIPTION
This package is a plugin for `moment` and as such it needs `moment` to be a dependency. But, as a plugin, it should not directly require `moment`; it should use the version required by the package that uses this package, to avoid having mismatching versions of moment.

This change ensures that when a repository installs this package, no `moment` will be installed along with it. This plugin will instead rely on the `moment` package that the parent repository is using (or will require the parent repository to install `moment`).